### PR TITLE
Feature: Add Severe Drop Indicator for Stocks

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -36,6 +36,43 @@
   margin-bottom: 8px;
 }
 
+/* New styles for severe drops section */
+.severe-drops {
+  background-color: #ffebee;
+  padding: 15px;
+  border-radius: 5px;
+  margin-top: 15px;
+  border: 2px solid #b71c1c;
+  box-shadow: 0 0 10px rgba(183, 28, 28, 0.3);
+  animation: pulse-border 2s infinite;
+}
+
+.severe-drops h3 {
+  margin-top: 0;
+  color: #b71c1c;
+  font-weight: bold;
+}
+
+.severe-drops ul {
+  padding-left: 20px;
+}
+
+.severe-drops li {
+  margin-bottom: 8px;
+}
+
+@keyframes pulse-border {
+  0% {
+    box-shadow: 0 0 0 0 rgba(183, 28, 28, 0.4);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(183, 28, 28, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(183, 28, 28, 0);
+  }
+}
+
 .loading {
   display: flex;
   justify-content: center;

--- a/src/App.js
+++ b/src/App.js
@@ -21,6 +21,17 @@ function App() {
     fetchStocks();
   }, []);
 
+  // Get stocks with severe drops (30% or more)
+  const severeDropStocks = stocks.filter(stock => 
+    ((stock.currentPrice - stock.initialPrice) / stock.initialPrice) * 100 <= -30
+  );
+
+  // Get stocks with significant changes (10% or more but less than 30%)
+  const significantChangeStocks = stocks.filter(stock => {
+    const percentChange = ((stock.currentPrice - stock.initialPrice) / stock.initialPrice) * 100;
+    return Math.abs(percentChange) >= 10 && percentChange > -30;
+  });
+
   return (
     <div className="App">
       <Header />
@@ -32,33 +43,46 @@ function App() {
             <div className="dashboard-summary">
               <h2>Stock Dashboard</h2>
               <p>
-                Tracking {stocks.length} stocks with alerts for +/-10% changes
+                Tracking {stocks.length} stocks with alerts for +/-10% changes and severe drops (30%+)
               </p>
+              
+              {/* Display severe drop alerts - new section */}
+              {severeDropStocks.length > 0 && (
+                <div className="severe-drops">
+                  <h3 style={{ color: '#b71c1c' }}>⚠️ SEVERE DROP ALERTS:</h3>
+                  <ul>
+                    {severeDropStocks.map(stock => (
+                      <li key={stock.id} style={{ color: '#b71c1c', fontWeight: 'bold' }}>
+                        {stock.symbol}: 🚨 Down by {
+                          Math.abs(
+                            ((stock.currentPrice - stock.initialPrice) / stock.initialPrice) * 100
+                          ).toFixed(2)
+                        }%
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              
               {/* Display summary of stocks with significant changes */}
-              {stocks.filter(stock => 
-                Math.abs(((stock.currentPrice - stock.initialPrice) / stock.initialPrice) * 100) >= 10
-              ).length > 0 && (
+              {significantChangeStocks.length > 0 && (
                 <div className="significant-changes">
                   <h3>Significant Changes Alert:</h3>
                   <ul>
-                    {stocks
-                      .filter(stock => 
-                        Math.abs(((stock.currentPrice - stock.initialPrice) / stock.initialPrice) * 100) >= 10
-                      )
-                      .map(stock => (
+                    {significantChangeStocks.map(stock => {
+                      const percentChange = ((stock.currentPrice - stock.initialPrice) / stock.initialPrice) * 100;
+                      return (
                         <li key={stock.id}>
                           {stock.symbol}: {
-                            ((stock.currentPrice - stock.initialPrice) / stock.initialPrice) * 100 >= 10 
+                            percentChange >= 10 
                             ? '🔼 Up' 
                             : '🔽 Down'
                           } by {
-                            Math.abs(
-                              ((stock.currentPrice - stock.initialPrice) / stock.initialPrice) * 100
-                            ).toFixed(2)
+                            Math.abs(percentChange).toFixed(2)
                           }%
                         </li>
-                      ))
-                    }
+                      );
+                    })}
                   </ul>
                 </div>
               )}

--- a/src/components/StockCard.js
+++ b/src/components/StockCard.js
@@ -5,9 +5,11 @@ const StockCard = ({ stock }) => {
   const percentChange = ((stock.currentPrice - stock.initialPrice) / stock.initialPrice) * 100;
   const isPositive = percentChange > 0;
   const isSignificantChange = Math.abs(percentChange) >= 10;
+  // New check for severe drop (30% or more)
+  const isSevereDrop = percentChange <= -30;
 
   return (
-    <div className="stock-card">
+    <div className={`stock-card ${isSevereDrop ? 'severe-drop' : ''}`}>
       <div className="stock-header">
         <span className="stock-symbol">{stock.symbol}</span>
         <span className={`price-change ${isPositive ? 'positive' : 'negative'}`}>
@@ -25,7 +27,11 @@ const StockCard = ({ stock }) => {
         Initial: ${stock.initialPrice.toFixed(2)}
       </div>
       
-      {isSignificantChange && (
+      {isSevereDrop ? (
+        <div className="severe-drop-alert">
+          ⚠️ CRITICAL: Stock has dropped by 30% or more!
+        </div>
+      ) : isSignificantChange && (
         <div className={`alert ${percentChange <= -10 ? 'danger' : ''}`}>
           {percentChange >= 10 
             ? '🔼 Stock has risen by 10% or more!' 

--- a/src/data/stockData.js
+++ b/src/data/stockData.js
@@ -113,6 +113,25 @@ const stockData = [
       { date: '2025-03-09', price: 282.20 },
       { date: '2025-03-10', price: 280.25 },
     ]
+  },
+  {
+    id: 7,
+    symbol: 'NFLX',
+    name: 'Netflix, Inc.',
+    initialPrice: 550.00,
+    currentPrice: 380.75,
+    history: [
+      { date: '2025-03-01', price: 550.00 },
+      { date: '2025-03-02', price: 535.30 },
+      { date: '2025-03-03', price: 510.75 },
+      { date: '2025-03-04', price: 490.20 },
+      { date: '2025-03-05', price: 470.80 },
+      { date: '2025-03-06', price: 445.25 },
+      { date: '2025-03-07', price: 430.40 },
+      { date: '2025-03-08', price: 410.55 },
+      { date: '2025-03-09', price: 395.20 },
+      { date: '2025-03-10', price: 380.75 },
+    ]
   }
 ];
 

--- a/src/index.css
+++ b/src/index.css
@@ -100,3 +100,34 @@ code {
   background-color: #ff5252;
   color: white;
 }
+
+/* New style for severe drops (30% or more) */
+.severe-drop {
+  background-color: #b71c1c;
+  color: white;
+  border: 2px solid #ff5252;
+}
+
+.severe-drop-alert {
+  background-color: #b71c1c;
+  color: white;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-weight: bold;
+  margin-top: 10px;
+  display: inline-block;
+  border: 2px solid #ff5252;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(255, 82, 82, 0.7);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(255, 82, 82, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 82, 82, 0);
+  }
+}


### PR DESCRIPTION
## Feature Description

This PR adds a new feature to highlight stocks that have dropped by 30% or more from their initial price. This provides a clear visual indicator for users to quickly identify stocks experiencing severe losses.

### Changes Implemented:

1. **Enhanced the StockCard component:**
   - Added functionality to detect drops of 30% or more
   - Added special styling for cards with severe drops (darker red background)
   - Added a pulsing alert badge with warning text for severe drops

2. **Enhanced Dashboard Summary:**
   - Added a dedicated "SEVERE DROP ALERTS" section with red styling
   - Separated significant changes (10-29%) from severe drops (30%+)
   - Added animation effects to highlight urgency

3. **Updated CSS Styling:**
   - Added new classes for severe drop indicators
   - Added pulsing animation effects to draw attention
   - Enhanced contrast for better visibility

4. **Added Test Data:**
   - Added Netflix (NFLX) to the static data with a significant drop (30.77%)

### Testing:
- Verified that stocks with drops >= 30% display with red background
- Verified that the dashboard properly separates severe drops from other changes
- Verified that the styling and animations work correctly

### Screenshots:
[Screenshots would be attached in a real PR]

### Notes for Reviewers:
- The severe drop threshold (30%) can be easily adjusted if needed
- The styling approach keeps consistent with the existing design system
