### PR TITLE
Change the alerts from +/-10% to +/-5%

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stock Price Tracker
 
-A React application that tracks stock prices in real-time from Yahoo Finance and provides visual alerts when a stock rises above 10% or falls below 10% of its initial value, with special warnings for severe drops of 30% or more.
+A React application that tracks stock prices in real-time from Yahoo Finance and provides visual alerts when a stock rises above 5% or falls below 5% of its initial value, with special warnings for severe drops of 30% or more.
 
 ## Features
 
@@ -8,7 +8,7 @@ A React application that tracks stock prices in real-time from Yahoo Finance and
 - Visual indicators for significant price changes:
   - Green for positive changes
   - Red for negative changes
-  - Special alert badges for changes of 10% or more
+  - Special alert badges for changes of 5% or more
   - Critical warning alerts for drops of 30% or more
 - Responsive dashboard overview of multiple stocks
 - Detailed view for individual stock performance

--- a/src/App.js
+++ b/src/App.js
@@ -76,10 +76,10 @@ function App() {
     ((stock.currentPrice - stock.initialPrice) / stock.initialPrice) * 100 <= -30
   );
 
-  // Get stocks with significant changes (10% or more but less than 30%)
+  // Get stocks with significant changes (5% or more but less than 30%)
   const significantChangeStocks = stocks.filter(stock => {
     const percentChange = ((stock.currentPrice - stock.initialPrice) / stock.initialPrice) * 100;
-    return Math.abs(percentChange) >= 10 && percentChange > -30;
+    return Math.abs(percentChange) >= 5 && percentChange > -30;
   });
 
   return (
@@ -134,7 +134,7 @@ function App() {
             <div className="dashboard-summary">
               <h2>Real-Time Stock Dashboard</h2>
               <p>
-                Tracking {stocks.length} stocks with alerts for +/-10% changes and severe drops (30%+)
+                Tracking {stocks.length} stocks with alerts for +/-5% changes and severe drops (30%+)
               </p>
               <div className="tracked-symbols">
                 <h3>Tracked Stocks:</h3>
@@ -182,7 +182,7 @@ function App() {
                       return (
                         <li key={stock.id}>
                           {stock.symbol}: {
-                            percentChange >= 10 
+                            percentChange >= 5 
                             ? '🔼 Up' 
                             : '🔽 Down'
                           } by {

--- a/src/components/StockCard.js
+++ b/src/components/StockCard.js
@@ -4,7 +4,7 @@ const StockCard = ({ stock }) => {
   // Calculate percentage change
   const percentChange = ((stock.currentPrice - stock.initialPrice) / stock.initialPrice) * 100;
   const isPositive = percentChange > 0;
-  const isSignificantChange = Math.abs(percentChange) >= 10;
+  const isSignificantChange = Math.abs(percentChange) >= 5;
   // Check for severe drop (30% or more)
   const isSevereDrop = percentChange <= -30;
 
@@ -61,10 +61,10 @@ const StockCard = ({ stock }) => {
           ⚠️ CRITICAL: Stock has dropped by 30% or more!
         </div>
       ) : isSignificantChange && (
-        <div className={`alert ${percentChange <= -10 ? 'danger' : ''}`}>
-          {percentChange >= 10 
-            ? '🔼 Stock has risen by 10% or more!' 
-            : '🔽 Stock has fallen by 10% or more!'}
+        <div className={`alert ${percentChange <= -5 ? 'danger' : ''}`}>
+          {percentChange >= 5 
+            ? '🔼 Stock has risen by 5% or more!' 
+            : '🔽 Stock has fallen by 5% or more!'}
         </div>
       )}
       


### PR DESCRIPTION
This PR addresses Issue #3 by changing the alert threshold from +/-10% to +/-5% for stock price changes.

## Changes:
1. Updated `StockCard.js` to change the alert threshold from 10% to 5%
2. Updated `App.js` to change the filter threshold for significant changes from 10% to 5%
3. Updated the dashboard summary text to reflect the new 5% alert threshold
4. Updated `README.md` to reflect the new 5% threshold

## Testing:
- The alerts now trigger at a 5% change rather than 10%
- Severe drop alerts still trigger at 30%
- All UI elements reflect the new 5% threshold

Closes #3